### PR TITLE
don't mistake directories for executables

### DIFF
--- a/lib/resolve-script/find-executables.js
+++ b/lib/resolve-script/find-executables.js
@@ -5,7 +5,7 @@ var isExecutable = require('./is-executable')
 var _ = require('lodash')
 
 module.exports = function (pattern, cb) {
-  glob(pattern, function (er, results) {
+  glob(pattern, {nodir: true}, function (er, results) {
     if (er) return cb(er)
     async.map(results, function (result, cb) {
       isExecutable(result, function (er, itIsExecutable) {

--- a/lib/resolve-script/find-executables.test.js
+++ b/lib/resolve-script/find-executables.test.js
@@ -1,6 +1,8 @@
 var fs = require('fs')
 var path = require('path')
 var exec = require('child_process').exec
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
 
 module.exports = {
   beforeEach: function () {
@@ -56,6 +58,14 @@ module.exports = {
         assert.deepEqual(result, [this.foo1, this.foo2])
         done(er)
       }.bind(this))
+    }.bind(this))
+  },
+  dirFound: function (done) {
+    mkdirp.sync(this.foo1)
+    this.subject(path.resolve(__dirname, 'foo*'), function (er, result) {
+      assert.deepEqual(result, [])
+      rimraf.sync(this.foo1)
+      done(er)
     }.bind(this))
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "homepage": "https://github.com/testdouble/scripty#readme",
   "devDependencies": {
+    "assert": "^1.3.0",
     "intercept-stdout": "^0.1.2",
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2",
     "semver": "^5.1.0",
     "standard": "^6.0.8",


### PR DESCRIPTION
- add `assert` package and `rimraf` package for test

* * *

I ran into a problem wherein scripty thought a directory was a script.  Unfortunately, I'm unable to reproduce this in the context of the integration tests, though I tried.

- I have a `scripts/test/browser/` dir.  That dir has an `index.sh` and a `dev.sh`.
- The `scripts/test/` dir has an `index.sh` which invokes `test:browser`, `test:node`, `test:lint`, etc.
- Somewhere in there, scripty thinks `scripts/test/browser/` is a script to be executed:

```
Error: scripty - failed trying to read "/Volumes/alien/mochajs/mocha-core/scripts/test/browser":

EISDIR: illegal operation on a directory, read
internal/child_process.js:302
    throw errnoException(err, 'spawn');
    ^

Error: spawn EACCES
    at exports._errnoException (util.js:890:11)
    at ChildProcess.spawn (internal/child_process.js:302:11)
    at exports.spawn (child_process.js:367:9)
    at /Volumes/alien/forked/scripty/lib/scripty.js:30:17
    at /Volumes/alien/forked/scripty/node_modules/async/lib/async.js:718:13
    at iterate (/Volumes/alien/forked/scripty/node_modules/async/lib/async.js:262:13)
    at async.forEachOfSeries.async.eachOfSeries (/Volumes/alien/forked/scripty/node_modules/async/lib/async.js:281:9)
    at _parallel (/Volumes/alien/forked/scripty/node_modules/async/lib/async.js:717:9)
    at Object.async.series (/Volumes/alien/forked/scripty/node_modules/async/lib/async.js:739:9)
    at /Volumes/alien/forked/scripty/lib/scripty.js:14:11
```

This changes solves the issue.

Also, I included userland `assert`, as using the core `assert` is not recommended by the Node.js team.