### PR TITLE
Add an option to perform a dry run

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,6 +24,7 @@ if (!lifecycleEvent) {
   scripty(lifecycleEvent, {
     userArgs: process.argv.slice(2),
     parallel: process.env['SCRIPTY_PARALLEL'] === 'true',
+    dryRun: process.env['SCRIPTY_DRY_RUN'] === 'true',
     spawn: {
       stdio: 'inherit'
     },

--- a/lib/scripty.js
+++ b/lib/scripty.js
@@ -5,11 +5,17 @@ var async = require('async')
 var optionalOptionWrapper = require('./optional-option-wrapper')
 var resolveScript = require('./resolve-script')
 var printScript = require('./print-script')
+var logger = require('./log')
 
 module.exports = optionalOptionWrapper(function scripty (npmLifecycle, options, cb) {
   var asyncOperation = async[options.parallel ? 'parallel' : 'series']
   resolveScript(npmLifecycle, options.resolve, function (er, scriptFiles) {
     if (er) { return cb(er) }
+    if (options.dryRun) {
+      logger('This is a dry run. Executed scripts would be:\n')
+      logger(scriptFiles)
+      return cb(null, 0)
+    }
     asyncOperation(wrapScriptRunners(scriptFiles, options), function (er, codes) {
       cb(er, _.last(codes))
     })
@@ -17,6 +23,7 @@ module.exports = optionalOptionWrapper(function scripty (npmLifecycle, options, 
 }, {
   userArgs: [],
   parallel: false,
+  dryRun: false,
   spawn: {},
   resolve: {}
 })

--- a/lib/scripty.js
+++ b/lib/scripty.js
@@ -13,7 +13,7 @@ module.exports = optionalOptionWrapper(function scripty (npmLifecycle, options, 
     if (er) { return cb(er) }
     if (options.dryRun) {
       logger('This is a dry run. Executed scripts would be:\n')
-      logger(scriptFiles)
+      _.map(scriptFiles, printScript)
       return cb(null, 0)
     }
     asyncOperation(wrapScriptRunners(scriptFiles, options), function (er, codes) {

--- a/test/safe/dry-run.js
+++ b/test/safe/dry-run.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var _ = require('lodash')
 
 var runScripty = require('../run-scripty')
@@ -6,7 +5,11 @@ var log = require('../../lib/log')
 
 module.exports = function doesNotRunButPrintScripts (done) {
   runScripty('hello:world', {dryRun: true}, function (er, code, stdio) {
-    assert.includes(log.read(), 'built-in-scripts' + path.sep + 'hello' + path.sep + 'world')
+    if (process.platform === 'win32') {
+      assert.includes(log.read(), 'built-in-scripts-win\\hello\\world')
+    } else {
+      assert.includes(log.read(), 'built-in-scripts/hello/world')
+    }
     assert.ok(!_.includes(stdio.stdout, 'Hello, World!'), 'Stdout includes "Hello World!"')
     done(er)
   })

--- a/test/safe/dry-run.js
+++ b/test/safe/dry-run.js
@@ -1,0 +1,11 @@
+var runScripty = require('../run-scripty')
+var _ = require('lodash')
+var log = require('../../lib/log')
+
+module.exports = function doesNotRunButPrintScripts (done) {
+  runScripty('hello:world', {dryRun: true}, function (er, code, stdio) {
+    assert.includes(log.read(), 'built-in-scripts/hello/world')
+    assert.ok(!_.includes(stdio.stdout, 'Hello, World!'), 'Stdout includes "Hello World!"')
+    done(er)
+  })
+}

--- a/test/safe/dry-run.js
+++ b/test/safe/dry-run.js
@@ -1,10 +1,12 @@
-var runScripty = require('../run-scripty')
+var path = require('path')
 var _ = require('lodash')
+
+var runScripty = require('../run-scripty')
 var log = require('../../lib/log')
 
 module.exports = function doesNotRunButPrintScripts (done) {
   runScripty('hello:world', {dryRun: true}, function (er, code, stdio) {
-    assert.includes(log.read(), 'built-in-scripts/hello/world')
+    assert.includes(log.read(), 'built-in-scripts' + path.sep + 'hello' + path.sep + 'world')
     assert.ok(!_.includes(stdio.stdout, 'Hello, World!'), 'Stdout includes "Hello World!"')
     done(er)
   })

--- a/test/safe/dry-run.js
+++ b/test/safe/dry-run.js
@@ -1,16 +1,16 @@
-var _ = require('lodash')
-
 var runScripty = require('../run-scripty')
 var log = require('../../lib/log')
 
-module.exports = function doesNotRunButPrintScripts (done) {
+module.exports = function doesNotRunButPrintResolvedScripts (done) {
   runScripty('hello:world', {dryRun: true}, function (er, code, stdio) {
     if (process.platform === 'win32') {
       assert.includes(log.read(), 'built-in-scripts-win\\hello\\world')
+      assert.includes(log.read(), 'Hello, %WORLD%')
     } else {
       assert.includes(log.read(), 'built-in-scripts/hello/world')
+      assert.includes(log.read(), 'Hello, $WORLD')
     }
-    assert.ok(!_.includes(stdio.stdout, 'Hello, World!'), 'Stdout includes "Hello World!"')
+    assert.equal(stdio.stdout, '', 'There should be no script output on stdout')
     done(er)
   })
 }


### PR DESCRIPTION
You can now get information about the scripts that would be executed
if you'd run scripty without the dry run flag by setting the env
var SCRIPTY_DRY_RUN=true before executing.

This attempts to be a start to issue #13 and currently looks like:

<img width="595" alt="bildschirmfoto 2016-04-17 um 22 27 05" src="https://cloud.githubusercontent.com/assets/68024/14589818/9c1d3dfe-04eb-11e6-8ba8-9922425f02b7.png">
