### PR TITLE
add suggested documentation to FAQ section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,16 @@ try running `printenv` from a script some time!
 * **Why isn't my script executing?** - If your script isn't executing, make sure
 it's **executable**! In UNIX, this can be accomplished by running
 `chmod +x scripts/path/to/my/script`
+* **How can I expect my users to understand what this does?** Documenting your
+project's use of `scripty` in the `README` is probably a good idea. Here's 
+some copy pasta if you don't feel like writing it up yourself:
+
+  > ## npm scripts
+  > MyProject uses [`scripty`](https://github.com/testdouble/scripty) to organize
+  > npm scripts. The scripts are defined in the [`scripts`](/scripts) directory.
+  > In `package.json` you'll see the word `scripty` as opposed to the script
+  > content you'd expect. For more info, see 
+  > [scripty's GitHub](https://github.com/testdouble/scripty).
+
+  > {{ insert table containing script names and what they do, e.g.
+  > [this](https://github.com/ashleygwilliams/relational-node#scripts) }}


### PR DESCRIPTION
in response to https://github.com/testdouble/scripty/issues/31, i thought this might make a nice addition to the `README`