### PR TITLE
Adds an env var to trigger a silent mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ $ SCRIPTY_DRY_RUN=true npm run publish:danger:stuff
 This will print the path and contents of each script the command would execute in
 the order they would be executed if you were to run the command normally.
 
+### Silent mode
+
+In case you don't want to the output to be cluttered by the script contents, you
+can run scripty in silent mode:
+
+```
+$ SCRIPTY_SILENT=true npm run publish:danger:stuff
+```
+
+This will omit printing the path and contents of each script the command executes.
+
 ## Likely questions
 
 * **Is this black magic?** - Nope! For once, instilling some convention didn't

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ if (!lifecycleEvent) {
     userArgs: process.argv.slice(2),
     parallel: process.env['SCRIPTY_PARALLEL'] === 'true',
     dryRun: process.env['SCRIPTY_DRY_RUN'] === 'true',
+    silent: process.env['SCRIPTY_SILENT'] === 'true',
     spawn: {
       stdio: 'inherit'
     },

--- a/lib/run/spawn-script.js
+++ b/lib/run/spawn-script.js
@@ -3,7 +3,7 @@ var printScript = require('./print-script')
 var spawn = require('child_process').spawn
 
 module.exports = function (scriptFile, options, cb) {
-  printScript(scriptFile)
+  if (!options.silent) printScript(scriptFile)
   var userArgs = options.userArgs
   var child = spawn(scriptFile, userArgs, options.spawn)
   child.on('close', function (code) {

--- a/lib/scripty.js
+++ b/lib/scripty.js
@@ -11,6 +11,7 @@ module.exports = optionify(function scripty (npmLifecycle, options, cb) {
   userArgs: [],
   parallel: false,
   dryRun: false,
+  silent: false,
   spawn: {},
   resolve: {}
 })

--- a/test/safe/silent-test.js
+++ b/test/safe/silent-test.js
@@ -1,0 +1,9 @@
+var runScripty = require('../run-scripty')
+var log = require('../../lib/run/log')
+
+module.exports = function doesNotEchoScriptContentInSilentMode (done) {
+  runScripty('hello:world', {silent: true}, function (er, code, stdio) {
+    assert.equal(log.read(), '')
+    done(er)
+  })
+}


### PR DESCRIPTION
Setting the env var `SCRIPTY_SILENT=true` will not print script paths
and contents for a cleaner console output. Addresses #28 

<img width="586" alt="bildschirmfoto 2016-05-05 um 17 35 53" src="https://cloud.githubusercontent.com/assets/68024/15048228/ed3c1a42-12e8-11e6-9215-b31e297eb648.png">
