### PR TITLE
Allow all configuration via package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ variable in your package.json:
 
 Which will run any sub-scripts in parallel whenever you run `npm run watch`.
 
+Finally, if you **always** want to run scripts in parallel, any option can be
+set in your package.json under a `"scripty"` entry:
+
+```json
+"scripty": {
+  "parallel": true
+}
+```
+
 ### Windows support
 
 Windows support is provided by scripty in two ways:
@@ -217,6 +226,15 @@ $ SCRIPTY_DRY_RUN=true npm run publish:danger:stuff
 This will print the path and contents of each script the command would execute in
 the order they would be executed if you were to run the command normally.
 
+Worth mentioning, like all options this can be set in package.json under a
+`"scripty"` entry:
+
+```json
+"scripty": {
+  "dryRun": true
+}
+```
+
 ### Silent mode
 
 In case you don't want to the output to be cluttered by the script contents, you
@@ -228,6 +246,14 @@ $ SCRIPTY_SILENT=true npm run publish:danger:stuff
 
 This will omit printing the path and contents of each script the command executes.
 
+If you always want scripty to run your scripts silently, you can set it in
+your package.json under a `"scripty"` entry:
+
+```json
+"scripty": {
+  "silent": true
+}
+```
 ## Likely questions
 
 * **Is this black magic?** - Nope! For once, instilling some convention didn't

--- a/cli.js
+++ b/cli.js
@@ -23,9 +23,9 @@ if (!lifecycleEvent) {
 
   scripty(lifecycleEvent, {
     userArgs: process.argv.slice(2),
-    parallel: process.env['SCRIPTY_PARALLEL'] === 'true',
-    dryRun: process.env['SCRIPTY_DRY_RUN'] === 'true',
-    silent: process.env['SCRIPTY_SILENT'] === 'true',
+    parallel: process.env.npm_package_scripty_parallel || process.env['SCRIPTY_PARALLEL'] === 'true',
+    dryRun: process.env.npm_package_scripty_dryRun || process.env['SCRIPTY_DRY_RUN'] === 'true',
+    silent: process.env.npm_package_scripty_silent || process.env['SCRIPTY_SILENT'] === 'true',
     spawn: {
       stdio: 'inherit'
     },

--- a/cli.js
+++ b/cli.js
@@ -20,18 +20,19 @@ if (!lifecycleEvent) {
   process.exit(1)
 } else {
   var scripty = require('./lib/scripty')
+  var loadOption = require('./lib/load-option')
 
   scripty(lifecycleEvent, {
     userArgs: process.argv.slice(2),
-    parallel: process.env.npm_package_scripty_parallel || process.env['SCRIPTY_PARALLEL'] === 'true',
-    dryRun: process.env.npm_package_scripty_dryRun || process.env['SCRIPTY_DRY_RUN'] === 'true',
-    silent: process.env.npm_package_scripty_silent || process.env['SCRIPTY_SILENT'] === 'true',
+    parallel: loadOption('parallel'),
+    dryRun: loadOption('dryRun'),
+    silent: loadOption('silent'),
     spawn: {
       stdio: 'inherit'
     },
     resolve: {
-      scripts: process.env.npm_package_scripty_path,
-      scriptsWin: process.env.npm_package_scripty_windowsPath
+      scripts: loadOption('path'),
+      scriptsWin: loadOption('windowsPath')
     }
   }, function (er, code) {
     if (er) { throw er }

--- a/lib/load-option.js
+++ b/lib/load-option.js
@@ -1,0 +1,8 @@
+var _ = require('lodash')
+
+module.exports = function loadOption (name) {
+  var env = process.env['SCRIPTY_' + _.snakeCase(name).toUpperCase()]
+  var pkg = process.env['npm_package_scripty_' + name]
+
+  return env === 'true' || (env !== 'false' && pkg === 'true')
+}

--- a/lib/load-option.test.js
+++ b/lib/load-option.test.js
@@ -1,0 +1,40 @@
+var subject = require('./load-option')
+
+module.exports = {
+  beforeEach: function () {
+    delete process.env.SCRIPTY_TEST_KEY
+    delete process.env.npm_package_scripty_testKey
+  },
+  envTrue: function () {
+    process.env.SCRIPTY_TEST_KEY = 'true'
+
+    assert.equal(subject('testKey'), true)
+  },
+  envFalse: function () {
+    process.env.SCRIPTY_TEST_KEY = 'false'
+
+    assert.equal(subject('testKey'), false)
+  },
+  packageTrue: function () {
+    process.env.npm_package_scripty_testKey = true
+
+    assert.equal(subject('testKey'), true)
+  },
+  packageFalse: function () {
+    process.env.npm_package_scripty_testKey = false
+
+    assert.equal(subject('testKey'), false)
+  },
+  envOverrideTrue: function () {
+    process.env.SCRIPTY_TEST_KEY = 'true'
+    process.env.npm_package_scripty_testKey = false
+
+    assert.equal(subject('testKey'), true)
+  },
+  envOverrideFalse: function () {
+    process.env.SCRIPTY_TEST_KEY = 'false'
+    process.env.npm_package_scripty_testKey = true
+
+    assert.equal(subject('testKey'), false)
+  }
+}


### PR DESCRIPTION
Options like `silent` have not previously been available in `package.json` (alongside `path`, for example). This changes that.

While the style may leave something to be desired, the function is all here, and I can style it how you like.