### PR TITLE
Fix loading custom scripts.

### DIFF
--- a/lib/load-option.js
+++ b/lib/load-option.js
@@ -2,7 +2,14 @@ var _ = require('lodash')
 
 module.exports = function loadOption (name) {
   var env = process.env['SCRIPTY_' + _.snakeCase(name).toUpperCase()]
+
+  if (env === 'true') return true
+  if (env === 'false') return false
+  if (env) return env
+
   var pkg = process.env['npm_package_scripty_' + name]
 
-  return env === 'true' || (env !== 'false' && pkg === 'true')
+  if (pkg === 'true') return true
+  if (pkg === 'false') return false
+  if (pkg) return pkg
 }

--- a/lib/load-option.test.js
+++ b/lib/load-option.test.js
@@ -36,5 +36,21 @@ module.exports = {
     process.env.npm_package_scripty_testKey = true
 
     assert.equal(subject('testKey'), false)
+  },
+  packageString: function () {
+    process.env.npm_package_scripty_testKey = 'some value'
+
+    assert.equal(subject('testKey'), 'some value')
+  },
+  envString: function () {
+    process.env.SCRIPTY_TEST_KEY = 'some value'
+
+    assert.equal(subject('testKey'), 'some value')
+  },
+  envOverrideString: function () {
+    process.env.SCRIPTY_TEST_KEY = 'right value'
+    process.env.npm_package_scripty_testKey = 'wrong value'
+
+    assert.equal(subject('testKey'), 'right value')
   }
 }

--- a/test/fixtures/relative-path-loading/package.json
+++ b/test/fixtures/relative-path-loading/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "relative-path-loading",
+  "version": "0.0.0",
+  "scripts": {
+    "secret": "scripty"
+  },
+  "scripty": {
+    "path": "../custom-user-scripts"
+  }
+}

--- a/test/safe/relative-path-loading.js
+++ b/test/safe/relative-path-loading.js
@@ -5,12 +5,13 @@ var grabStdio = require('../grab-stdio')
 module.exports = {
   'loads scripts from a relative path': function (done) {
     var stdio = {}
+    var windowsSuffix = process.platform === 'win32' ? '-win' : ''
     var child = fork('../../../cli', [], {
       cwd: path.join(__dirname, '..', 'fixtures', 'relative-path-loading'),
       silent: true,
       env: {
         npm_lifecycle_event: 'secret',
-        npm_package_scripty_path: '../custom-user-scripts',
+        npm_package_scripty_path: '../custom-user-scripts' + windowsSuffix,
         SCRIPTY_SILENT: true
       }
     })

--- a/test/safe/relative-path-loading.js
+++ b/test/safe/relative-path-loading.js
@@ -1,0 +1,27 @@
+var fork = require('child_process').fork
+var path = require('path')
+var grabStdio = require('../grab-stdio')
+
+module.exports = {
+  'loads scripts from a relative path': function (done) {
+    var stdio = {}
+    var child = fork('../../../cli', [], {
+      cwd: path.join(__dirname, '..', 'fixtures', 'relative-path-loading'),
+      silent: true,
+      env: {
+        npm_lifecycle_event: 'secret',
+        npm_package_scripty_path: '../custom-user-scripts',
+        SCRIPTY_SILENT: true
+      }
+    })
+
+    grabStdio(stdio)(child)
+
+    child.on('exit', function (code) {
+      assert.equal(code, 0)
+      assert.includes(stdio.stdout, 'SSHHH')
+
+      done()
+    })
+  }
+}


### PR DESCRIPTION
As it turns out, the option loading change in v1.7.0 was overzealously applied _all_ options, though it only _worked_ with Booleans. Now, `loadOption` works for Booleans and Strings, as intended.

Fixes #45.