### PR TITLE
fix: let scripty work on windows with cross-spawn

### DIFF
--- a/lib/run/spawn-script.js
+++ b/lib/run/spawn-script.js
@@ -1,6 +1,6 @@
 var _ = require('lodash')
 var printScript = require('./print-script')
-var spawn = require('child_process').spawn
+var spawn = require('cross-spawn')
 
 module.exports = function (scriptFile, options, cb) {
   if (!options.silent) printScript(scriptFile)
@@ -18,4 +18,3 @@ module.exports = function (scriptFile, options, cb) {
   })
   _.invoke(options, 'spawn.tap', child)
 }
-

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "cross-spawn": "^5.0.1",
     "glob": "^7.0.3",
     "lodash": "^4.8.2"
   },


### PR DESCRIPTION
I want to add `scripty` to our package.json scripts for [`nyc`](https://github.com/istanbuljs/nyc) but we run our tests on Windows as well: https://ci.appveyor.com/project/bcoe/nyc-ilw23/build/517/job/iw8xy6x945c9l2qu

~~@searls please let me know if there's anything I'm missing! Thanks!~~

FWIW these tests are passing locally on my macOS machine, though I had a bit of a derp moment when I noticed you run your tests on appveyor already...

What am I doing wrong? 😕 