### PR TITLE
Clean up exits.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,6 @@ if (!lifecycleEvent) {
       scriptsWin: loadOption('windowsPath')
     }
   }, function (er, code) {
-    if (er) { throw er }
-    process.exit(code)
+    process.exitCode = code
   })
 }


### PR DESCRIPTION
If a script exits with a non-zero code, scripty will no longer throw a noisy error.

Furthermore, setting process.exitCode allows the process tree to terminate normally, rather than forcibly killing it with process.exit().