### PR TITLE
Support singular 'script' dirname convention

### DIFF
--- a/lib/resolve-script/script-dirs.js
+++ b/lib/resolve-script/script-dirs.js
@@ -18,10 +18,14 @@ function find (base, options, key, platform) {
     return options[key + 'Win']
   } else if (platform === 'win32' && fs.existsSync(path.resolve(base, 'scripts-win'))) {
     return path.resolve(base, 'scripts-win')
+  } else if (platform === 'win32' && fs.existsSync(path.resolve(base, 'script-win'))) {
+    return path.resolve(base, 'script-win')
   } else if (options[key]) {
     return options[key]
-  } else {
+  } else if (fs.existsSync(path.resolve(base, 'scripts'))) {
     return path.resolve(base, 'scripts')
+  } else {
+    return path.resolve(base, 'script')
   }
 }
 

--- a/lib/resolve-script/script-dirs.test.js
+++ b/lib/resolve-script/script-dirs.test.js
@@ -1,29 +1,78 @@
 var path = require('path')
 
+function cd (dir) {
+  td.when(td.replace(process, 'cwd')()).thenReturn(dir)
+}
+
 module.exports = {
   beforeEach: function () {
     this.resolvePkg = td.replace('resolve-pkg')
     this.subject = require('./script-dirs')
   },
-  unixUserScripts: function () {
-    assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'lolnix').userDir, 'A')
-    assert.equal(this.subject({ scripts: null, scriptsWin: 'B' }, 'lolnix').userDir,
-      path.resolve(process.cwd(), 'scripts'))
+  unixUserScripts: {
+    'prefer scripts key if set': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/with-all'))
+
+      assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'lolnix').userDir, 'A')
+    },
+
+    'first fallback to scripts if it exists': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/with-all'))
+
+      assert.equal(this.subject({ scripts: null, scriptsWin: 'B' }, 'lolnix').userDir,
+        path.resolve(process.cwd(), 'scripts'))
+    },
+
+    'final fallback to script': function () {
+      cd(__dirname)
+      assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'lolnix').userDir,
+        path.resolve(process.cwd(), 'script'))
+    }
   },
   unixBuiltInScripts: function () {
     assert.equal(this.subject({ builtIn: 'A', builtInWin: 'B' }, 'lolnix').ourDir, 'A')
     assert.equal(this.subject({ builtIn: null, builtInWin: 'B' }, 'lolnix').ourDir,
       path.resolve(__dirname, '../../scripts'))
   },
-  windowsUserScripts: function () {
-    assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'win32').userDir, 'B')
-    assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir,
-      path.resolve(process.cwd(), 'scripts-win'))
-    // change dirs to any place that lacks a ./scripts-win dir
-    td.when(td.replace(process, 'cwd')()).thenReturn(__dirname)
-    assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir, 'A')
-    assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'win32').userDir,
-      path.resolve(process.cwd(), 'scripts'))
+  windowsUserScripts: {
+    'prefer scriptsWin value if set': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all', 'with-all'))
+
+      assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'win32').userDir, 'B')
+    },
+
+    'first fallback to scripts-win if exists': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all', 'with-all'))
+
+      assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir,
+        path.resolve(process.cwd(), 'scripts-win'))
+    },
+
+    'second fallback to script-win if it exists': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-scripts-win'))
+
+      assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir,
+        path.resolve(process.cwd(), 'script-win'))
+    },
+
+    'third fallback to scripts key if set': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-win'))
+
+      assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir, 'A')
+    },
+
+    'fourth fallback to scripts if it exists': function () {
+      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-win'))
+
+      assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'win32').userDir,
+        path.resolve(process.cwd(), 'scripts'))
+    },
+
+    'final fallback to script': function () {
+      cd(__dirname)
+      assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'win32').userDir,
+        path.resolve(process.cwd(), 'script'))
+    }
   },
   windowsBuiltIn: function () {
     assert.equal(this.subject({ builtIn: 'A', builtInWin: 'B' }, 'win32').ourDir, 'B')
@@ -38,7 +87,7 @@ module.exports = {
         modules: ['bar']
       },
       'lolnix'
-      ).moduleDirs, [path.resolve(process.cwd(), 'node_modules/bar/scripts')]
+      ).moduleDirs, [path.resolve(process.cwd(), 'node_modules/bar/script')]
     )
   }
 }

--- a/lib/resolve-script/script-dirs.test.js
+++ b/lib/resolve-script/script-dirs.test.js
@@ -1,93 +1,104 @@
 var path = require('path')
 
-function cd (dir) {
-  td.when(td.replace(process, 'cwd')()).thenReturn(dir)
-}
-
 module.exports = {
   beforeEach: function () {
     this.resolvePkg = td.replace('resolve-pkg')
+    this.fsExistsSync = td.replace('fs').existsSync
     this.subject = require('./script-dirs')
   },
   unixUserScripts: {
     'prefer scripts key if set': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/with-all'))
-
       assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'lolnix').userDir, 'A')
     },
 
     'first fallback to scripts if it exists': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/with-all'))
-
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(true)
       assert.equal(this.subject({ scripts: null, scriptsWin: 'B' }, 'lolnix').userDir,
         path.resolve(process.cwd(), 'scripts'))
     },
 
     'final fallback to script': function () {
-      cd(__dirname)
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(false)
       assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'lolnix').userDir,
         path.resolve(process.cwd(), 'script'))
     }
   },
   unixBuiltInScripts: function () {
+    td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(true)
     assert.equal(this.subject({ builtIn: 'A', builtInWin: 'B' }, 'lolnix').ourDir, 'A')
     assert.equal(this.subject({ builtIn: null, builtInWin: 'B' }, 'lolnix').ourDir,
       path.resolve(__dirname, '../../scripts'))
   },
   windowsUserScripts: {
     'prefer scriptsWin value if set': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all', 'with-all'))
-
       assert.equal(this.subject({ scripts: 'A', scriptsWin: 'B' }, 'win32').userDir, 'B')
     },
 
     'first fallback to scripts-win if exists': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all', 'with-all'))
-
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(true)
       assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir,
         path.resolve(process.cwd(), 'scripts-win'))
     },
 
     'second fallback to script-win if it exists': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-scripts-win'))
-
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/script-win$/))).thenReturn(true)
       assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir,
         path.resolve(process.cwd(), 'script-win'))
     },
 
     'third fallback to scripts key if set': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-win'))
-
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/script-win$/))).thenReturn(false)
       assert.equal(this.subject({ scripts: 'A', scriptsWin: null }, 'win32').userDir, 'A')
     },
 
     'fourth fallback to scripts if it exists': function () {
-      cd(path.resolve('test/fixtures/scripts-to-rule-them-all/no-win'))
-
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/script-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(true)
       assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'win32').userDir,
         path.resolve(process.cwd(), 'scripts'))
     },
 
     'final fallback to script': function () {
-      cd(__dirname)
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/script-win$/))).thenReturn(false)
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(false)
       assert.equal(this.subject({ scripts: null, scriptsWin: null }, 'win32').userDir,
         path.resolve(process.cwd(), 'script'))
     }
   },
   windowsBuiltIn: function () {
+    td.when(this.fsExistsSync(td.matchers.contains(/scripts-win$/))).thenReturn(true)
     assert.equal(this.subject({ builtIn: 'A', builtInWin: 'B' }, 'win32').ourDir, 'B')
     assert.equal(this.subject({ builtIn: 'A', builtInWin: null }, 'win32').ourDir,
       path.resolve(__dirname, '../../scripts-win'))
   },
-  moduleDirs: function () {
-    td.when(this.resolvePkg('bar')).thenReturn('node_modules/bar')
+  moduleDirs: {
+    'prefer scripts if it exists': function () {
+      td.when(this.resolvePkg('bar')).thenReturn('node_modules/bar')
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(true)
 
-    assert.deepEqual(
-      this.subject({
-        modules: ['bar']
-      },
-      'lolnix'
-      ).moduleDirs, [path.resolve(process.cwd(), 'node_modules/bar/script')]
-    )
+      assert.deepEqual(
+        this.subject({
+          modules: ['bar']
+        },
+        'lolnix'
+        ).moduleDirs, [path.resolve(process.cwd(), 'node_modules/bar/scripts')]
+      )
+    },
+
+    'fallback to script': function () {
+      td.when(this.resolvePkg('bar')).thenReturn('node_modules/bar')
+      td.when(this.fsExistsSync(td.matchers.contains(/scripts$/))).thenReturn(false)
+      assert.deepEqual(
+        this.subject({
+          modules: ['bar']
+        },
+        'lolnix'
+        ).moduleDirs, [path.resolve(process.cwd(), 'node_modules/bar/script')]
+      )
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -219,7 +219,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -444,7 +444,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -788,7 +788,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -974,7 +974,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -1348,7 +1348,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -1638,7 +1638,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -1919,7 +1919,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2005,7 +2005,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -2246,7 +2246,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -2478,7 +2478,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2636,7 +2636,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },


### PR DESCRIPTION
I can't find any documentation or any source that finds either of 'scripts' or 'script' to be more common in practice.

Absent any data, I lean only on anecdotal experience when I find 'script' to be more common in the wild than 'scripts'.

To further defend this, GitHub has [blogged](https://githubengineering.com/scripts-to-rule-them-all/) their "Scripts to Rule Them All" pattern, and for it they use 'script' singular.

This change adds 'script' (and 'script-win') as fallbacks if the plural version does not exist.

This _should_ be a semver minor change.

Any users who may incidentally already have both scripts and script directories, `scripts` will continue to be preferred (as long as it exists). The singular 'script' is only used as a fallback when `scripts` does _not_ exist.

The same is true for Windows users. `scripts-win` is preferred if both `scripts-win` and `script-win` exist.

The _only_ users who may experience an issue are Windows users who do not have a `scripts-win` directory but do have a `script-win` directory, for some reason. In this case, what _would_ have fallen back to `scripts` will now be preempted by `script-win`.

closes #52 