### PR TITLE
Omit test and misc files from npm tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 .node-version
 /coverage
+/scripty-*.tgz

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Because no one should be shell-scripting inside a JSON file.",
   "main": "lib/scripty.js",
   "bin": "cli.js",
+  "files": [
+    "cli.js",
+    "lib",
+    "scripts",
+    "scripts-win"
+  ],
   "scripts": {
     "test:unit": "teenytest \"lib/**/*.test.js\" --helper test/unit-helper.js",
     "test:safe": "teenytest \"test/safe/**/*.js\" --helper test/safe-helper.js",


### PR DESCRIPTION
This PR makes the tarball file listing explicit via `files` array in
package.json. It will eliminate test/ and example/ dirs, and the
extraneous hidden files in root.

Also adds its own tarball to gitignore, as is generated by any manual
npm-pack invocations.