### PR TITLE
Report errors by console-logging and exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,10 @@ if (!lifecycleEvent) {
       scriptsWin: loadOption('windowsPath')
     }
   }, function (er, code) {
+    if (er) {
+      console.error(er)
+      code = code || er.code || 1
+    }
     process.exitCode = code
   })
 }


### PR DESCRIPTION
Scripty is presently swallowing errors.
This behavior was introduced with https://github.com/testdouble/scripty/commit/d7a1296d04bc0875f67d738b9b36296b35b39fa1
presumably to silence noisy errors caused by the scripts themselves.

However, this has the side effect of _also_ muting errors raised by
scripty itself.

For instance, the common error of scripty being invoked but unable to
find a script to execute. In such a scenario, (even when not silent),
the only output printed is:

```
$ npm run bar

> foo@1.0.0 bar /path/to/foo
> scripty

```

What's worse, it exits with a zero (successful) status code.

This change ensures errors from scripty are logged to STDERR and exits
with a nonzero status code.
It _also_ makes any script errors a bit noisier (as they were before),
but that should be resolved separately with the more configurable
logging levels.