### PR TITLE
Drop Node 6 support, add 12 and 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
   - node
+  - 14
+  - 12
   - 10
   - 8
-  - 6
 after_script:
   - npm run test:cover
   - npm run test:cover:upload


### PR DESCRIPTION
Node 6 reached its end-of-life on 2019-04-30. Dropping Node 6 also makes CI pass. (It was broken by testdouble@3.15.0, which dropped support for Node 6 by way of quibble@0.6.x.)

I tend to think of dropping support for a Node version meaning a major version bump. But does that apply when the version is EOL? Or, I suppose Node 6 support is already dropped, but it just isn't official.